### PR TITLE
favour UK spelling of behaviour

### DIFF
--- a/src/plumtree_default_peer_service.erl
+++ b/src/plumtree_default_peer_service.erl
@@ -1,5 +1,5 @@
 -module(plumtree_default_peer_service).
--behavior(plumtree_peer_behavior).
+-behavior(plumtree_peer_behaviour).
 
 -export([get_peer_state/0,
 	 register_changes/1,

--- a/src/plumtree_peer_behaviour.erl
+++ b/src/plumtree_peer_behaviour.erl
@@ -1,4 +1,4 @@
--module(plumtree_peer_behavior).
+-module(plumtree_peer_behaviour).
 
 
 -type peer_state() :: any().


### PR DESCRIPTION
Really, this is odd, but doing s/behavior/behaviour/ worked for me.

Else, I get
[...]
==> plumtree (compile)
Compiling .../deps/plumtree/src/plumtree_default_peer_service.erl failed:
.../deps/plumtree/src/plumtree_default_peer_service.erl:2: behaviour plumtree_peer_behavior undefined
ERROR: compile failed while processing .../deps/plumtree: rebar_abort
