### PR TITLE
BDP + TS Merge

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_first_files, ["src/plumtree_peer_behavior.erl"]}.
 {erl_opts, [warnings_as_errors, debug_info, {parse_transform, lager_transform}]}.
 {deps, [
-        {lager, "2.0.3", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
+        {lager, "2.*", {git, "git://github.com/basho/lager.git", {branch, "2.x"}}},
         {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {branch, "develop"}}},
         {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {tag, "2.0.2"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,4 @@
+{erl_first_files, ["src/plumtree_peer_behavior.erl"]}.
 {erl_opts, [warnings_as_errors, debug_info, {parse_transform, lager_transform}]}.
 {deps, [
         {lager, "2.0.3", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},


### PR DESCRIPTION
This PR enables proper building of the Basho version of Plumtree in sync with the BDP+TS PR, which is located here: https://github.com/basho/data_platform_ee/pull/6
